### PR TITLE
build.zig: replace std.Build.Step.Compile.defineCMacro() call with std.Build.Module.addCMacro()

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -43,7 +43,7 @@ pub fn build(b: *std.Build) void {
         "-Wall",
         "-Wextra",
     } });
-    lib.defineCMacro("__USE_MINGW_ANSI_STDIO", "1");
+    lib.root_module.addCMacro("__USE_MINGW_ANSI_STDIO", "1");
     lib.addIncludePath(b.path("include"));
     lib.addIncludePath(b.path("src"));
     lib.linkLibC();


### PR DESCRIPTION
Hi,

The title says everything. It allows successful compilation for both zig 0.13.0 and zig 0.14.0

Thank you.